### PR TITLE
manual mode read from .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+ETH_IP=172.17.0.1
+SEQ_RPC_URL=http://172.17.0.1:34709/ext/bc/qSprVavtgBPdPVAFYgw3vYcDd9453yrsMLc3hxX74H9m7Z6vx


### PR DESCRIPTION
Manual mode read ETH-L1 ip and nodekit-seq rpc url from .env rather than passing them as flags 